### PR TITLE
Better handling of boolean arguments in query string for Python

### DIFF
--- a/src/exporters/python.ts
+++ b/src/exporters/python.ts
@@ -57,6 +57,15 @@ export class PythonExporter implements FormatExporter {
           return result;
         } else if (PYCONSTANTS[lines[0]]) {
           return PYCONSTANTS[lines[0]];
+        } else if (lines[0].startsWith('"') && lines[0].endsWith('"')) {
+          // special case: handle strings such as "true", "false" or "null" as
+          // their native types
+          const s = lines[0].substring(1, lines[0].length - 1);
+          if (PYCONSTANTS[s]) {
+            return PYCONSTANTS[s];
+          } else {
+            return lines[0];
+          }
         } else {
           return lines[0];
         }

--- a/tests/integration/skip.ts
+++ b/tests/integration/skip.ts
@@ -386,6 +386,14 @@ const skip: Record<string, SkippedTest> = {
   "083e514297c09e91211f0d168aef1b0b": {
     reason: "example uses bad format for comments",
   },
+  b22559a7c319f90bc63a41cac1c39b4c: {
+    reason: "test passes boolean field as string",
+    formats: ["python"],
+  },
+  cfad3631be0634ee49c424f9ccec62d9: {
+    reason: "test passes boolean field as string",
+    formats: ["python"],
+  },
 };
 
 export function shouldBeSkipped(


### PR DESCRIPTION
Query string arguments such as `?human`, `?human=true` or `?human=false` should be converted to bool arguments in the exported Python code.