### PR TITLE
Wrap JS examples in async functions

### DIFF
--- a/src/exporters/javascript.tpl
+++ b/src/exporters/javascript.tpl
@@ -8,6 +8,8 @@ const client = new Client({
   },
 })
 
+async function run() {
+
 {{/if}}
 {{#each requests}}
 {{#supportedApi}}
@@ -47,3 +49,13 @@ console.log(response{{#if @index}}{{@index}}{{/if}})
 {{/if}}
 
 {{/each}}
+
+{{#if complete}}
+}
+
+{{#if ../printResponse}}
+run().then(console.log).catch(console.error)
+{{else}}
+run()
+{{/if}}
+{{/if}}

--- a/tests/convert.test.ts
+++ b/tests/convert.test.ts
@@ -173,6 +173,38 @@ const response1 = await client.search({
     );
   });
 
+  it("converts to a complete javascript snippet with full async compatibility", async () => {
+    expect(
+      await convertRequests(devConsoleScript, "javascript", { complete: true }),
+    ).toEqual(
+      `const { Client } = require("@elastic/elasticsearch");
+
+const client = new Client({
+  nodes: [process.env["ELASTICSEARCH_URL"]],
+  auth: {
+    apiKey: process.env["ELASTIC_API_KEY"],
+  },
+});
+
+async function run() {
+  const response = await client.info();
+
+  const response1 = await client.search({
+    index: "my-index",
+    from: 40,
+    size: 20,
+    query: {
+      term: {
+        "user.id": "kimchy's",
+      },
+    },
+  });
+}
+
+run();
+`,
+    );
+  });
   it("supports a custom exporter", async () => {
     class MyExporter implements FormatExporter {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/tests/integration/skip.ts
+++ b/tests/integration/skip.ts
@@ -498,6 +498,11 @@ const skip: Record<string, SkippedTest> = {
       "test uses username in path, but client sends it in the body as well, which is valid",
     formats: ["javascript"],
   },
+  f187ac2dc35425cb0ef48f328cc7e435: {
+    reason:
+      "test uses username in path, but client sends it in the body as well, which is valid",
+    formats: ["javascript"],
+  },
 };
 
 export function shouldBeSkipped(


### PR DESCRIPTION
When generating a complete example that should be runnable, the code needs to be wrapped in an `async` function, or run in an environment that supports top-level `await`. I chose the former, since it's still the most common way to handle async in JS.
