### PR TITLE
attempt to fix random js testing errors and timeouts

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint": "eslint src tests",
     "prettier": "prettier \"src/**/*.ts\" \"tests/**/*.ts\" --list-different",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --test-path-ignore-patterns integration --coverage",
-    "test:setup": "node scripts/download-examples.mjs && ./tests/integration/run-python.sh",
+    "test:setup": "node scripts/download-examples.mjs && ./tests/integration/run-python.sh && ./tests/integration/run-javascript.sh",
     "test:integration": "node --experimental-vm-modules node_modules/jest/bin/jest.js tests/integration",
     "test:integration-curl": "./scripts/test-format.sh curl",
     "test:integration-python": "./scripts/test-format.sh python",

--- a/scripts/test-example.sh
+++ b/scripts/test-example.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 export ONLY_EXAMPLE=$1
-jest tests/integration/convert.test.ts
+node --experimental-vm-modules node_modules/jest/bin/jest.js tests/integration/convert.test.ts

--- a/tests/integration/run-javascript.sh
+++ b/tests/integration/run-javascript.sh
@@ -23,7 +23,6 @@ if [ ! -d "$SCRIPT_DIR" ]; then
   npm init -y
   npm install
   npm install "$CLIENT_DIR"
-  npm run build
   popd
 fi
 


### PR DESCRIPTION
I've added a call to `run-javascript.sh` in the `test:setup` command, so that the testing client is installed ahead of the tests. I think one of the problems is that when the installation of the client happens when the first test runs the test ends up running for longer than the 5 second timeout imposed by jest. 🤞 