### PR TITLE
export the listFormats function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,9 @@
-export { convertRequests, ConvertOptions, FormatExporter } from "./convert";
+export {
+  listFormats,
+  convertRequests,
+  ConvertOptions,
+  FormatExporter,
+} from "./convert";
 export {
   parseRequests,
   ParseOptions,


### PR DESCRIPTION
The `listFormats()` was inadvertently left out of the exported list. 