### PR TITLE
treat bodies as of type 'value' when not described in schema

### DIFF
--- a/src/exporters/javascript.ts
+++ b/src/exporters/javascript.ts
@@ -94,7 +94,7 @@ export class JavaScriptExporter implements FormatExporter {
       Handlebars.registerHelper(
         "ifRequestBodyKind",
         function (this: ParsedRequest, kind: string, options) {
-          const bodyKind = this.request?.body?.kind;
+          const bodyKind = this.request?.body?.kind || "value";
 
           if (bodyKind == kind) {
             return options.fn(this);

--- a/src/exporters/javascript.ts
+++ b/src/exporters/javascript.ts
@@ -94,7 +94,7 @@ export class JavaScriptExporter implements FormatExporter {
       Handlebars.registerHelper(
         "ifRequestBodyKind",
         function (this: ParsedRequest, kind: string, options) {
-          const bodyKind = this.request?.body?.kind || "value";
+          const bodyKind = this.request?.body?.kind ?? "value";
 
           if (bodyKind == kind) {
             return options.fn(this);

--- a/src/exporters/python.tpl
+++ b/src/exporters/python.tpl
@@ -24,7 +24,7 @@ resp{{#if @index}}{{@index}}{{/if}} = client.{{this.api}}(
     {{/each}}
     {{else ifRequestBodyKind "value"}}
     {{#if this.request.body.codegenName}}{{this.request.body.codegenName}}{{else}}body{{/if}}={{{pyprint this.body}}},
-    {{/ifRequestBodyKind}}
+{{/ifRequestBodyKind}}
 )
 {{else}}
 resp{{#if @index}}{{@index}}{{/if}} = client.{{this.api}}()

--- a/src/exporters/python.ts
+++ b/src/exporters/python.ts
@@ -133,7 +133,7 @@ export class PythonExporter implements FormatExporter {
       Handlebars.registerHelper(
         "ifRequestBodyKind",
         function (this: ParsedRequest, kind: string, options) {
-          let bodyKind = this.request?.body?.kind || "value";
+          let bodyKind = this.request?.body?.kind ?? "value";
           const parsedBody = typeof this.body == "object" ? this.body : {};
           if (this.api == "search" && "sub_searches" in parsedBody) {
             // Change the kind of any search requests that use sub-searches to

--- a/src/exporters/python.ts
+++ b/src/exporters/python.ts
@@ -133,7 +133,7 @@ export class PythonExporter implements FormatExporter {
       Handlebars.registerHelper(
         "ifRequestBodyKind",
         function (this: ParsedRequest, kind: string, options) {
-          let bodyKind = this.request?.body?.kind;
+          let bodyKind = this.request?.body?.kind || "value";
           const parsedBody = typeof this.body == "object" ? this.body : {};
           if (this.api == "search" && "sub_searches" in parsedBody) {
             // Change the kind of any search requests that use sub-searches to


### PR DESCRIPTION
It appears there are some endpoints in the schema that use a body, but do not have an explicit description of it. Example:

```json
    {
      "availability": {
        "stack": {
          "stability": "stable",
          "visibility": "public"
        }
      },
      "description": "Puts the configuration for a geoip database to be downloaded",
      "docUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/master/TODO.html",
      "name": "ingest.put_geoip_database",
      "request": null,
      "requestBodyRequired": true,
      "response": null,
      "responseMediaType": [
        "application/json"
      ],
      "stability": "stable",
      "urls": [
        {
          "methods": [
            "PUT"
          ],
          "path": "/_ingest/geoip/database/{id}"
        }
      ],
      "visibility": "public"
    },
```

With the current logic, the `request` attribute being `null` causes the Python and JavaScript exporters to ignore the body. With this change, these endpoints will be treated as having a body with `kind == 'value'`, which makes the exporters output the body as a generic object.