### PR TITLE
fix(NA): run execAsync from childProcess with util.promisify

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   ],
   "devDependencies": {
     "@eslint/js": "^9.3.0",
-    "@types/child-process-promise": "^2.2.6",
     "@types/jest": "^29.5.12",
     "@types/jest-expect-message": "^1.1.0",
     "@types/node": "^20.12.12",
@@ -60,7 +59,6 @@
     "typescript-eslint": "^7.10.0"
   },
   "dependencies": {
-    "child-process-promise": "^2.2.1",
     "commander": "^12.1.0",
     "find-my-way-ts": "^0.1.2",
     "handlebars": "^4.7.8",

--- a/tests/integration/convert.test.ts
+++ b/tests/integration/convert.test.ts
@@ -1,11 +1,14 @@
 import { readFileSync } from "fs";
 import { writeFile, rm } from "fs/promises";
+import childProcess from "child-process";
 import path from "path";
-import { exec } from "child-process-promise";
+import util from "util";
 import { convertRequests } from "../../src/convert";
 import { parseRequest, splitSource, ParsedRequest } from "../../src/parse";
 import { startServer, stopServer } from "./testserver";
 import { shouldBeSkipped } from "./skip";
+
+const execAsync = util.promisify(childProcess.exec);
 
 const TEST_FORMATS: Record<string, string> = {
   python: "py",
@@ -89,7 +92,7 @@ describe("convert", () => {
           const failureMessage = `Failed code snippet:\n\n${code}\n\n`;
 
           try {
-            await exec(
+            await execAsync(
               path.join(__dirname, `./run-${format}.sh .tmp.request.${ext}`),
             );
             parsedRequest = await parseRequest(source);


### PR DESCRIPTION
This PR removes the usage of `child-process-promise` and uses native node util functions instead.