### PR TITLE
PHP: escape dollar variables

### DIFF
--- a/src/exporters/php.ts
+++ b/src/exporters/php.ts
@@ -70,7 +70,10 @@ export class PHPExporter implements FormatExporter {
     } else if (data === null || data === undefined) {
       return (startIndented ? indent : "") + "null";
     } else if (typeof data === "string") {
-      return (startIndented ? indent : "") + JSON.stringify(data);
+      return (
+        (startIndented ? indent : "") +
+        JSON.stringify(data).replaceAll("${", "\\${")
+      );
     } else if (Array.isArray(data)) {
       const elements =
         data.length === 0

--- a/tests/convert.test.ts
+++ b/tests/convert.test.ts
@@ -398,6 +398,24 @@ $resp1 = $client->search([
     );
   });
 
+  it("converts a dollar-variable to php", async () => {
+    expect(
+      await convertRequests('POST /my-index/_doc\n{"key":"${value}"}', "php", {
+        complete: false,
+        elasticsearchUrl: "https://localhost:9999",
+      }),
+    ).toEqual(
+      `$resp = $client->index([
+    "index" => "my-index",
+    "body" => [
+        "key" => "\\\${value}",
+    ],
+]);
+
+`,
+    );
+  });
+
   it("converts an unsupported API to php", async () => {
     expect(
       await convertRequests("GET /_internal/desired_balance", "php", {


### PR DESCRIPTION
Some examples in the specification use the pattern `${variable_name}` to denote a placeholder. Unfortunately in PHP this is interpreted as a variable replacement. With this change these are rendered escaped, to avoid them producing unknown variable errors.