### PR TITLE
Restrict push trigger to main branch in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,10 @@
 name: CI
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
The push trigger in the CI workflow now only runs on the main branch, while pull_request continues to trigger on all PRs. This avoids unnecessary CI runs on feature branches and reduces resource usage.

Stops CI double triggering in PRs