### PR TITLE
Pin the C# bundle peer dependency to the latest dist-tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "prettier": "^2.8.8"
   },
   "peerDependencies": {
-    "@elastic/request-converter-dotnet": ">=8.19.0"
+    "@elastic/request-converter-dotnet": "latest"
   },
   "peerDependenciesMeta": {
     "@elastic/request-converter-dotnet": {


### PR DESCRIPTION
## Summary

- Changes the optional `@elastic/request-converter-dotnet` peer dependency from `>=8.19.0` to the `latest` dist-tag, so `main` tracks the newest published bundle.
- The release branches pin the matching per-branch tag instead (`latest-9.5`, `latest-9.4`, `latest-8.19`) via the open backport PRs #108/#109/#110.

Since the peer is optional, npm never resolves or validates the tag automatically; it serves as install guidance (`npm install @elastic/request-converter-dotnet@latest`).

Note: the bundle publish workflow currently only applies the per-branch `latest-x.y` tag when the published version is not the newest, so the newest minor only carries `latest`. The workflow in elasticsearch-net should be updated to always add the per-branch tag as well.