### PR TITLE
Publish older-branch releases with a per-branch dist-tag

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -24,4 +24,21 @@ jobs:
       - run: npm install
       - run: npm run build
       - run: npm test
-      - run: npm publish --access public
+      # npm refuses to publish a version lower than the current "latest" without
+      # an explicit dist-tag (it won't move "latest" backwards). Tag "latest" only
+      # for the highest version; otherwise use "latest-<branch>". The "latest-"
+      # prefix avoids a bare branch name like "9.4", which npm rejects as a
+      # dist-tag because it parses as a semver range.
+      - name: Compute dist-tag
+        id: dist-tag
+        run: |
+          CURRENT_LATEST=$(npm view @elastic/request-converter version 2>/dev/null || echo "0.0.0")
+          NEW_VERSION=$(jq -r .version package.json)
+          if [ "$(printf '%s\n%s\n' "$CURRENT_LATEST" "$NEW_VERSION" | sort -V | tail -n1)" = "$NEW_VERSION" ]; then
+            TAG="latest"
+          else
+            TAG="latest-${{ github.event.inputs.branch }}"
+          fi
+          echo "Publishing ${NEW_VERSION} with dist-tag ${TAG} (current latest: ${CURRENT_LATEST})"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+      - run: npm publish --access public --tag "${{ steps.dist-tag.outputs.tag }}"


### PR DESCRIPTION
## Summary

Adds a "Compute dist-tag" step to the npm publish workflow so older-branch patch releases publish under `latest-<branch>` instead of failing.

## Intention

npm refuses to publish a version lower than the current `latest` without an explicit `--tag` (it won't move `latest` backwards). So patch releases on older branches (e.g. 9.4.1 or 8.19.2 while `latest` is 9.5.0) fail at the publish step with `Cannot implicitly apply the "latest" tag`. This mirrors the dist-tag logic already used in the elasticsearch-net publish workflow.

## Changes

- New "Compute dist-tag" step compares the new version to the current `latest` via `npm view @elastic/request-converter version`; tags `latest` when the new version is the highest, otherwise `latest-<branch>`.
- `npm publish` now passes `--tag` with the computed tag.

## Notes

- One tag per publish: OIDC trusted publishing has no token for `npm dist-tag add`, so the newest release gets `latest` only and does not also get `latest-<branch>`. The `latest-<branch>` tag for the newest minor appears only once a newer minor supersedes it and a patch ships.
- Backport labels (8.19, 9.4, 9.5) added so the backport workflow propagates this to the release branches.
- Once merged, the publish can be re-dispatched for 9.4 (9.4.1 -> `latest-9.4`) and 8.19 (8.19.2 -> `latest-8.19`); those release commits are already on the branches.