### PR TITLE
[Backport 8.19] Publish older-branch releases with a per-branch dist-tag

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,12 +17,28 @@ jobs:
           ref: ${{ github.event.inputs.branch }}
       - uses: actions/setup-node@v3
         with:
-          node-version: "20.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
-      - run: npm install -g npm
+      - name: Update npm
+        run: npm install -g npm@latest
       - run: npm install
       - run: npm run build
       - run: npm test
-      - run: npm publish --access public --tag previous
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # npm refuses to publish a version lower than the current "latest" without
+      # an explicit dist-tag (it won't move "latest" backwards). Tag "latest" only
+      # for the highest version; otherwise use "latest-<branch>". The "latest-"
+      # prefix avoids a bare branch name like "9.4", which npm rejects as a
+      # dist-tag because it parses as a semver range.
+      - name: Compute dist-tag
+        id: dist-tag
+        run: |
+          CURRENT_LATEST=$(npm view @elastic/request-converter version 2>/dev/null || echo "0.0.0")
+          NEW_VERSION=$(jq -r .version package.json)
+          if [ "$(printf '%s\n%s\n' "$CURRENT_LATEST" "$NEW_VERSION" | sort -V | tail -n1)" = "$NEW_VERSION" ]; then
+            TAG="latest"
+          else
+            TAG="latest-${{ github.event.inputs.branch }}"
+          fi
+          echo "Publishing ${NEW_VERSION} with dist-tag ${TAG} (current latest: ${CURRENT_LATEST})"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+      - run: npm publish --access public --tag "${{ steps.dist-tag.outputs.tag }}"


### PR DESCRIPTION
## Summary

Backport of #112 to 8.19: adds the "Compute dist-tag" step and modernizes the publish workflow to match main.

## Intention

npm refuses to publish a version lower than the current `latest` without an explicit `--tag`. The 8.19 branch still used the old workflow (`NPM_TOKEN` + `--tag previous`); that token is the expired one main already removed, so 8.19.x can't publish as-is.

## Changes

- Replaces `.github/workflows/npm-publish.yml` with the version on main (post-#112): OIDC trusted publishing (no token), `latest` for the highest version, otherwise `latest-<branch>`.
- 8.19.x now publishes as `latest-8.19` instead of `previous`.