### PR TITLE
[Backport 8.19] Pass helpers to templates at render time instead of registering them globally

### DIFF
--- a/src/exporters/javascript.ts
+++ b/src/exporters/javascript.ts
@@ -11,6 +11,7 @@ const UNSUPPORTED_APIS = new RegExp("^_internal.*$");
 
 export class JavaScriptExporter implements FormatExporter {
   _template: Handlebars.TemplateDelegate;
+  _helpers: Record<string, Handlebars.HelperDelegate> | undefined;
 
   async check(requests: ParsedRequest[]): Promise<boolean> {
     // only return true if all requests are for Elasticsearch
@@ -26,29 +27,37 @@ export class JavaScriptExporter implements FormatExporter {
     if (!(await this.check(requests))) {
       throw new Error("Cannot perform conversion");
     }
-    const output = this.template({ requests, ...options });
+    const output = this.template(
+      { requests, ...options },
+      { helpers: this.helpers },
+    );
     return prettier.format(output, {
       parser: "typescript",
       plugins: [prettierTypeScript],
     });
   }
 
-  get template(): Handlebars.TemplateDelegate {
-    if (!this._template) {
-      Handlebars.registerHelper("json", function (context) {
-        const val = JSON.stringify(context ?? null, null, 2);
+  // Helpers are handed to the template at render time instead of being
+  // registered on the global Handlebars environment, because every exporter
+  // defines helpers under the same names but with different behavior.
+  get helpers(): Record<string, Handlebars.HelperDelegate> {
+    if (!this._helpers) {
+      this._helpers = {
+        json: function (context) {
+          const val = JSON.stringify(context ?? null, null, 2);
 
-        // turn number strings into numbers
-        if (val.match(/^"\d+"$/)) {
-          return parseInt(val.replaceAll('"', ""), 10);
-        }
-        return val;
-      });
+          // turn number strings into numbers
+          if (val.match(/^"\d+"$/)) {
+            return parseInt(val.replaceAll('"', ""), 10);
+          }
+          return val;
+        },
 
-      // custom conditional for requests without any arguments
-      Handlebars.registerHelper(
-        "hasArgs",
-        function (this: ParsedRequest, options) {
+        // custom conditional for requests without any arguments
+        hasArgs: function (
+          this: ParsedRequest,
+          options: Handlebars.HelperOptions,
+        ) {
           if (
             Object.keys(this.params ?? {}).length +
               Object.keys(this.query ?? {}).length +
@@ -60,40 +69,41 @@ export class JavaScriptExporter implements FormatExporter {
             return options.inverse(this);
           }
         },
-      );
 
-      // custom conditional to separate supported vs unsupported APIs
-      Handlebars.registerHelper(
-        "supportedApi",
-        function (this: ParsedRequest, options) {
+        // custom conditional to separate supported vs unsupported APIs
+        supportedApi: function (
+          this: ParsedRequest,
+          options: Handlebars.HelperOptions,
+        ) {
           if (!UNSUPPORTED_APIS.test(this.api as string) && this.request) {
             return options.fn(this);
           } else {
             return options.inverse(this);
           }
         },
-      );
 
-      // attribute name renderer that considers aliases and code-specific names
-      // arguments:
-      //   name: the name of the attribute
-      //   props: the list of schema properties this attribute belongs to
-      Handlebars.registerHelper("alias", (name, props) => {
-        if (props) {
-          for (const prop of props) {
-            if (prop.name == name && prop.codegenName != undefined) {
-              return prop.codegenName;
+        // attribute name renderer that considers aliases and code-specific names
+        // arguments:
+        //   name: the name of the attribute
+        //   props: the list of schema properties this attribute belongs to
+        alias: (name, props) => {
+          if (props) {
+            for (const prop of props) {
+              if (prop.name == name && prop.codegenName != undefined) {
+                return prop.codegenName;
+              }
             }
           }
-        }
-        return name;
-      });
+          return name;
+        },
 
-      // custom conditional to check for request body kind
-      // the argument can be "properties" or "value"
-      Handlebars.registerHelper(
-        "ifRequestBodyKind",
-        function (this: ParsedRequest, kind: string, options) {
+        // custom conditional to check for request body kind
+        // the argument can be "properties" or "value"
+        ifRequestBodyKind: function (
+          this: ParsedRequest,
+          kind: string,
+          options: Handlebars.HelperOptions,
+        ) {
           const bodyKind = this.request?.body?.kind ?? "value";
 
           if (bodyKind == kind) {
@@ -102,10 +112,15 @@ export class JavaScriptExporter implements FormatExporter {
             return options.inverse(this);
           }
         },
-      );
 
-      Handlebars.registerHelper("camelCase", (text) => toCamelCase(text));
+        camelCase: (text) => toCamelCase(text),
+      };
+    }
+    return this._helpers;
+  }
 
+  get template(): Handlebars.TemplateDelegate {
+    if (!this._template) {
       if (process.env.NODE_ENV !== "test") {
         this._template = Handlebars.templates["javascript.tpl"];
       } else {

--- a/src/exporters/php.ts
+++ b/src/exporters/php.ts
@@ -44,6 +44,7 @@ function isSupportedAPI(req: ParsedRequest) {
 
 export class PHPExporter implements FormatExporter {
   template: Handlebars.TemplateDelegate | undefined;
+  helpers: Record<string, Handlebars.HelperDelegate> | undefined;
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async check(requests: ParsedRequest[]): Promise<boolean> {
@@ -60,7 +61,8 @@ export class PHPExporter implements FormatExporter {
     if (!(await this.check(requests))) {
       throw new Error("Cannot perform conversion");
     }
-    return (await this.getTemplate())({ requests, ...options });
+    const template = await this.getTemplate();
+    return template({ requests, ...options }, { helpers: this.getHelpers() });
   }
 
   phpprint(data: jsontype, indent: string, startIndented: boolean): string {
@@ -113,19 +115,20 @@ export class PHPExporter implements FormatExporter {
     }
   }
 
-  async getTemplate(): Promise<Handlebars.TemplateDelegate> {
-    if (!this.template) {
-      // custom data renderer for Python
-      Handlebars.registerHelper("phpprint", (context) => {
-        return this.phpprint(context, "", false);
-      });
+  // Helpers are handed to the template at render time instead of being
+  // registered on the global Handlebars environment, because every exporter
+  // defines helpers under the same names but with different behavior.
+  getHelpers(): Record<string, Handlebars.HelperDelegate> {
+    if (!this.helpers) {
+      this.helpers = {
+        // custom data renderer for PHP
+        phpprint: (context) => {
+          return this.phpprint(context, "", false);
+        },
 
-      //
-      Handlebars.registerHelper(
-        "needsRequestFactory",
-        function (
+        needsRequestFactory: function (
           this: { requests: ParsedRequest[] } & ConvertOptions,
-          options,
+          options: Handlebars.HelperOptions,
         ) {
           let anyUnsupported = false;
           for (const request of this.requests) {
@@ -140,12 +143,12 @@ export class PHPExporter implements FormatExporter {
             return options.inverse(this);
           }
         },
-      );
 
-      // custom conditional for requests without any arguments
-      Handlebars.registerHelper(
-        "hasArgs",
-        function (this: ParsedRequest, options) {
+        // custom conditional for requests without any arguments
+        hasArgs: function (
+          this: ParsedRequest,
+          options: Handlebars.HelperOptions,
+        ) {
           if (
             Object.keys(this.params ?? {}).length +
               Object.keys(this.query ?? {}).length +
@@ -157,34 +160,43 @@ export class PHPExporter implements FormatExporter {
             return options.inverse(this);
           }
         },
-      );
 
-      // custom conditional to separate supported vs unsupported APIs
-      Handlebars.registerHelper(
-        "supportedApi",
-        function (this: ParsedRequest, options) {
+        // custom conditional to separate supported vs unsupported APIs
+        supportedApi: function (
+          this: ParsedRequest,
+          options: Handlebars.HelperOptions,
+        ) {
           if (isSupportedAPI(this)) {
             return options.fn(this);
           } else {
             return options.inverse(this);
           }
         },
-      );
 
-      Handlebars.registerHelper("phpEndpoint", (name) => {
-        const snakeToCamel = (str: string) =>
-          str
-            .toLowerCase()
-            .replace(/([-_][a-z])/g, (group) =>
-              group.toUpperCase().replace("-", "").replace("_", ""),
-            );
+        phpEndpoint: (name) => {
+          const snakeToCamel = (str: string) =>
+            str
+              .toLowerCase()
+              .replace(/([-_][a-z])/g, (group) =>
+                group.toUpperCase().replace("-", "").replace("_", ""),
+              );
 
-        const parts = name.split(".").map((part: string) => snakeToCamel(part));
-        const phpParts = parts.slice(0, -1).map((part: string) => part + "()");
-        phpParts.push(parts.slice(-1));
-        return phpParts.join("->");
-      });
+          const parts = name
+            .split(".")
+            .map((part: string) => snakeToCamel(part));
+          const phpParts = parts
+            .slice(0, -1)
+            .map((part: string) => part + "()");
+          phpParts.push(parts.slice(-1));
+          return phpParts.join("->");
+        },
+      };
+    }
+    return this.helpers;
+  }
 
+  async getTemplate(): Promise<Handlebars.TemplateDelegate> {
+    if (!this.template) {
       if (process.env.NODE_ENV !== "test") {
         this.template = Handlebars.templates["php.tpl"];
       } else {

--- a/src/exporters/python.ts
+++ b/src/exporters/python.ts
@@ -18,6 +18,7 @@ const PYCONSTANTS: Record<string, string> = {
 
 export class PythonExporter implements FormatExporter {
   template: Handlebars.TemplateDelegate | undefined;
+  helpers: Record<string, Handlebars.HelperDelegate> | undefined;
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async check(requests: ParsedRequest[]): Promise<boolean> {
@@ -34,44 +35,50 @@ export class PythonExporter implements FormatExporter {
     if (!(await this.check(requests))) {
       throw new Error("Cannot perform conversion");
     }
-    return (await this.getTemplate())({ requests, ...options });
+    const template = await this.getTemplate();
+    return template({ requests, ...options }, { helpers: this.getHelpers() });
   }
 
-  async getTemplate(): Promise<Handlebars.TemplateDelegate> {
-    if (!this.template) {
-      // custom data renderer for Python
-      Handlebars.registerHelper("pyprint", (context) => {
-        const lines = JSON.stringify(context ?? null, null, 4).split(/\r?\n/);
-        for (let i = 1; i < lines.length; i++) {
-          lines[i] = "    " + lines[i];
-        }
-        if (lines.length > 1) {
-          let result = lines.join("\n");
-          for (const k of Object.keys(PYCONSTANTS)) {
-            result = result.replaceAll(`${k},\n`, `${PYCONSTANTS[k]},\n`);
-            result = result.replaceAll(`${k}\n`, `${PYCONSTANTS[k]}\n`);
+  // Helpers are handed to the template at render time instead of being
+  // registered on the global Handlebars environment, because every exporter
+  // defines helpers under the same names but with different behavior.
+  getHelpers(): Record<string, Handlebars.HelperDelegate> {
+    if (!this.helpers) {
+      this.helpers = {
+        // custom data renderer for Python
+        pyprint: (context) => {
+          const lines = JSON.stringify(context ?? null, null, 4).split(/\r?\n/);
+          for (let i = 1; i < lines.length; i++) {
+            lines[i] = "    " + lines[i];
           }
-          return result;
-        } else if (PYCONSTANTS[lines[0]]) {
-          return PYCONSTANTS[lines[0]];
-        } else if (lines[0].startsWith('"') && lines[0].endsWith('"')) {
-          // special case: handle strings such as "true", "false" or "null" as
-          // their native types
-          const s = lines[0].substring(1, lines[0].length - 1);
-          if (PYCONSTANTS[s]) {
-            return PYCONSTANTS[s];
+          if (lines.length > 1) {
+            let result = lines.join("\n");
+            for (const k of Object.keys(PYCONSTANTS)) {
+              result = result.replaceAll(`${k},\n`, `${PYCONSTANTS[k]},\n`);
+              result = result.replaceAll(`${k}\n`, `${PYCONSTANTS[k]}\n`);
+            }
+            return result;
+          } else if (PYCONSTANTS[lines[0]]) {
+            return PYCONSTANTS[lines[0]];
+          } else if (lines[0].startsWith('"') && lines[0].endsWith('"')) {
+            // special case: handle strings such as "true", "false" or "null" as
+            // their native types
+            const s = lines[0].substring(1, lines[0].length - 1);
+            if (PYCONSTANTS[s]) {
+              return PYCONSTANTS[s];
+            } else {
+              return lines[0];
+            }
           } else {
             return lines[0];
           }
-        } else {
-          return lines[0];
-        }
-      });
+        },
 
-      // custom conditional for requests without any arguments
-      Handlebars.registerHelper(
-        "hasArgs",
-        function (this: ParsedRequest, options) {
+        // custom conditional for requests without any arguments
+        hasArgs: function (
+          this: ParsedRequest,
+          options: Handlebars.HelperOptions,
+        ) {
           if (
             Object.keys(this.params ?? {}).length +
               Object.keys(this.query ?? {}).length +
@@ -83,52 +90,53 @@ export class PythonExporter implements FormatExporter {
             return options.inverse(this);
           }
         },
-      );
 
-      // custom conditional to separate supported vs unsupported APIs
-      Handlebars.registerHelper(
-        "supportedApi",
-        function (this: ParsedRequest, options) {
+        // custom conditional to separate supported vs unsupported APIs
+        supportedApi: function (
+          this: ParsedRequest,
+          options: Handlebars.HelperOptions,
+        ) {
           if (!UNSUPPORTED_APIS.test(this.api as string) && this.request) {
             return options.fn(this);
           } else {
             return options.inverse(this);
           }
         },
-      );
 
-      // attribute name renderer that considers aliases and code-specific names
-      // arguments:
-      //   name: the name of the attribute
-      //   props: the list of schema properties this attribute belongs to
-      Handlebars.registerHelper("alias", (name, props) => {
-        const aliases: Record<string, string> = {
-          from: "from_",
-          _meta: "meta",
-          _field_names: "field_names",
-          _routing: "routing",
-          _source: "source",
-          _source_excludes: "source_excludes",
-          _source_includes: "source_includes",
-        };
-        if (aliases[name]) {
-          return aliases[name];
-        }
-        if (props) {
-          for (const prop of props) {
-            if (prop.name == name && prop.codegenName != undefined) {
-              return prop.codegenName;
+        // attribute name renderer that considers aliases and code-specific names
+        // arguments:
+        //   name: the name of the attribute
+        //   props: the list of schema properties this attribute belongs to
+        alias: (name, props) => {
+          const aliases: Record<string, string> = {
+            from: "from_",
+            _meta: "meta",
+            _field_names: "field_names",
+            _routing: "routing",
+            _source: "source",
+            _source_excludes: "source_excludes",
+            _source_includes: "source_includes",
+          };
+          if (aliases[name]) {
+            return aliases[name];
+          }
+          if (props) {
+            for (const prop of props) {
+              if (prop.name == name && prop.codegenName != undefined) {
+                return prop.codegenName;
+              }
             }
           }
-        }
-        return name.replaceAll("-", "_").replaceAll(".", "_");
-      });
+          return name.replaceAll("-", "_").replaceAll(".", "_");
+        },
 
-      // custom conditional to check for request body kind
-      // the argument can be "properties" or "value"
-      Handlebars.registerHelper(
-        "ifRequestBodyKind",
-        function (this: ParsedRequest, kind: string, options) {
+        // custom conditional to check for request body kind
+        // the argument can be "properties" or "value"
+        ifRequestBodyKind: function (
+          this: ParsedRequest,
+          kind: string,
+          options: Handlebars.HelperOptions,
+        ) {
           let bodyKind = this.request?.body?.kind ?? "value";
           const parsedBody = typeof this.body == "object" ? this.body : {};
           if (this.api == "search" && "sub_searches" in parsedBody) {
@@ -144,8 +152,13 @@ export class PythonExporter implements FormatExporter {
             return options.inverse(this);
           }
         },
-      );
+      };
+    }
+    return this.helpers;
+  }
 
+  async getTemplate(): Promise<Handlebars.TemplateDelegate> {
+    if (!this.template) {
       if (process.env.NODE_ENV !== "test") {
         this.template = Handlebars.templates["python.tpl"];
       } else {

--- a/src/exporters/ruby.ts
+++ b/src/exporters/ruby.ts
@@ -26,6 +26,7 @@ function isSupportedAPI(req: ParsedRequest) {
 
 export class RubyExporter implements FormatExporter {
   template: Handlebars.TemplateDelegate | undefined;
+  helpers: Record<string, Handlebars.HelperDelegate> | undefined;
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async check(requests: ParsedRequest[]): Promise<boolean> {
@@ -42,44 +43,50 @@ export class RubyExporter implements FormatExporter {
     if (!(await this.check(requests))) {
       throw new Error("Cannot perform conversion");
     }
-    return (await this.getTemplate())({ requests, ...options });
+    const template = await this.getTemplate();
+    return template({ requests, ...options }, { helpers: this.getHelpers() });
   }
 
-  async getTemplate(): Promise<Handlebars.TemplateDelegate> {
-    if (!this.template) {
-      // custom data renderer for Ruby
-      Handlebars.registerHelper("rubyprint", (context) => {
-        const lines = JSON.stringify(context ?? null, null, 2).split(/\r?\n/);
-        for (let i = 1; i < lines.length; i++) {
-          lines[i] = "  " + lines[i];
-        }
-        if (lines.length > 1) {
-          let result = lines.join("\n");
-          for (const k of Object.keys(RUBYCONSTANTS)) {
-            result = result.replaceAll(`${k},\n`, `${RUBYCONSTANTS[k]},\n`);
-            result = result.replaceAll(`${k}\n`, `${RUBYCONSTANTS[k]}\n`);
+  // Helpers are handed to the template at render time instead of being
+  // registered on the global Handlebars environment, because every exporter
+  // defines helpers under the same names but with different behavior.
+  getHelpers(): Record<string, Handlebars.HelperDelegate> {
+    if (!this.helpers) {
+      this.helpers = {
+        // custom data renderer for Ruby
+        rubyprint: (context) => {
+          const lines = JSON.stringify(context ?? null, null, 2).split(/\r?\n/);
+          for (let i = 1; i < lines.length; i++) {
+            lines[i] = "  " + lines[i];
           }
-          return result;
-        } else if (RUBYCONSTANTS[lines[0]]) {
-          return RUBYCONSTANTS[lines[0]];
-        } else if (lines[0].startsWith('"') && lines[0].endsWith('"')) {
-          // special case: handle strings such as "null" as
-          // their native types
-          const s = lines[0].substring(1, lines[0].length - 1);
-          if (RUBYCONSTANTS[s]) {
-            return RUBYCONSTANTS[s];
+          if (lines.length > 1) {
+            let result = lines.join("\n");
+            for (const k of Object.keys(RUBYCONSTANTS)) {
+              result = result.replaceAll(`${k},\n`, `${RUBYCONSTANTS[k]},\n`);
+              result = result.replaceAll(`${k}\n`, `${RUBYCONSTANTS[k]}\n`);
+            }
+            return result;
+          } else if (RUBYCONSTANTS[lines[0]]) {
+            return RUBYCONSTANTS[lines[0]];
+          } else if (lines[0].startsWith('"') && lines[0].endsWith('"')) {
+            // special case: handle strings such as "null" as
+            // their native types
+            const s = lines[0].substring(1, lines[0].length - 1);
+            if (RUBYCONSTANTS[s]) {
+              return RUBYCONSTANTS[s];
+            } else {
+              return lines[0];
+            }
           } else {
             return lines[0];
           }
-        } else {
-          return lines[0];
-        }
-      });
+        },
 
-      // custom conditional for requests without any arguments
-      Handlebars.registerHelper(
-        "hasArgs",
-        function (this: ParsedRequest, options) {
+        // custom conditional for requests without any arguments
+        hasArgs: function (
+          this: ParsedRequest,
+          options: Handlebars.HelperOptions,
+        ) {
           if (
             Object.keys(this.params ?? {}).length +
               Object.keys(this.query ?? {}).length +
@@ -91,47 +98,52 @@ export class RubyExporter implements FormatExporter {
             return options.inverse(this);
           }
         },
-      );
 
-      // custom conditional to separate supported vs unsupported APIs
-      Handlebars.registerHelper(
-        "supportedApi",
-        function (this: ParsedRequest, options) {
+        // custom conditional to separate supported vs unsupported APIs
+        supportedApi: function (
+          this: ParsedRequest,
+          options: Handlebars.HelperOptions,
+        ) {
           if (isSupportedAPI(this)) {
             return options.fn(this);
           } else {
             return options.inverse(this);
           }
         },
-      );
 
-      // attribute name renderer that considers aliases and code-specific names
-      // arguments:
-      //   name: the name of the attribute
-      //   props: the list of schema properties this attribute belongs to
-      // TODO: I don't think any of these are necessary in Ruby, but check for others
-      Handlebars.registerHelper("alias", (name, props) => {
-        const aliases: Record<string, string> = {
-          _meta: "meta",
-          _field_names: "field_names",
-          _routing: "routing",
-          _source: "source",
-          _source_excludes: "source_excludes",
-          _source_includes: "source_includes",
-        };
-        if (aliases[name]) {
-          return aliases[name];
-        }
-        if (props) {
-          for (const prop of props) {
-            if (prop.name == name && prop.codegenName != undefined) {
-              return prop.codegenName;
+        // attribute name renderer that considers aliases and code-specific names
+        // arguments:
+        //   name: the name of the attribute
+        //   props: the list of schema properties this attribute belongs to
+        // TODO: I don't think any of these are necessary in Ruby, but check for others
+        alias: (name, props) => {
+          const aliases: Record<string, string> = {
+            _meta: "meta",
+            _field_names: "field_names",
+            _routing: "routing",
+            _source: "source",
+            _source_excludes: "source_excludes",
+            _source_includes: "source_includes",
+          };
+          if (aliases[name]) {
+            return aliases[name];
+          }
+          if (props) {
+            for (const prop of props) {
+              if (prop.name == name && prop.codegenName != undefined) {
+                return prop.codegenName;
+              }
             }
           }
-        }
-        return name;
-      });
+          return name;
+        },
+      };
+    }
+    return this.helpers;
+  }
 
+  async getTemplate(): Promise<Handlebars.TemplateDelegate> {
+    if (!this.template) {
       if (process.env.NODE_ENV !== "test") {
         this.template = Handlebars.templates["ruby.tpl"];
       } else {

--- a/tests/convert.test.ts
+++ b/tests/convert.test.ts
@@ -603,6 +603,28 @@ response1 = client.search(
     ).rejects.toThrowError("Cannot perform conversion");
   });
 
+  it("converts each language independently of conversion order", async () => {
+    // Every template exporter defines helpers under the same names ("alias",
+    // "supportedApi", "hasArgs", ...) but with language specific behavior, so
+    // converting one language must not affect the output of any other.
+    const formats = ["python", "javascript", "php", "ruby"];
+    const expected: Record<string, string> = {};
+    for (const format of formats) {
+      expected[format] = (await convertRequests(
+        devConsoleScript,
+        format,
+        {},
+      )) as string;
+    }
+
+    // convert again, now that every exporter has been initialized
+    for (const format of formats) {
+      expect(await convertRequests(devConsoleScript, format, {})).toEqual(
+        expected[format],
+      );
+    }
+  });
+
   it("supports a custom exporter", async () => {
     class MyExporter implements FormatExporter {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
Backport 5d693c55790c020a6616b2e2a5a5e15e1ff59c57 from #120.

The cherry-pick conflicted in `src/exporters/python.ts` because `main` gained two changes after 8.19 diverged: the `availability`/feature-flag check in `supportedApi` and the `if: "if_"` alias. The conflict was resolved by keeping 8.19's logic for both, so this backport is purely the structural change from #120 (helpers passed at render time instead of registered globally).
