### PR TITLE
Document and test the C# client call option pass-through

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # request-converter change log
 
+## Unreleased
+
+- Document and test pass-through of the C# exporter's `client_call_format` and `client_call_style` options
+
 ## 9.2.1 (2025-11-12)
 * Write correctly formatted ndjson bodies in the curl exporter ([#99](https://github.com/elastic/request-converter/pull/99))
 * Fix CLI's `--elasticsearch-url` option ([#98](https://github.com/elastic/request-converter/pull/98))

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Document and test pass-through of the C# exporter's `client_call_format` and `client_call_style` options
+* Document and test pass-through of the C# exporter's `client_call_format` and `client_call_style` options
 
 ## 9.2.1 (2025-11-12)
 * Write correctly formatted ndjson bodies in the curl exporter ([#99](https://github.com/elastic/request-converter/pull/99))

--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ Supported options (snake_case, matching the .NET bundle's wire contract):
 | `use_strongly_typed_document` | `boolean` | no | If `true`, field accessors use lambdas on an illustrative document type. The default is `true`. |
 | `document_type_name` | `string` | no | The document type name used in generated code. The default is `"MyDocument"`. |
 | `type_name_style` | `string` | no | `"Simplified"`, `"Fqn"`, or `"GlobalFqn"` type-name rendering. The default is `"Simplified"`. |
+| `client_call_format` | `string` | no | `"none"`, `"statement"`, or `"inline"`: whether and how the client invocation that executes the request is emitted. The default is `"none"`. |
+| `client_call_style` | `string` | no | `"async"` or `"sync"` invocation flavor when `client_call_format` is not `"none"`. The default is `"async"`. |
 | `debug` | `boolean` | no | If `true`, append converter diagnostics to error messages. The default is `false`. |
 
 ## Command-Line Interface

--- a/README.md
+++ b/README.md
@@ -164,13 +164,13 @@ Supported options (snake_case, matching the .NET bundle's wire contract):
 
 | Option name | Type | Required | Description |
 | ----------- | ---- | -------- | ----------- |
-| `syntax_mode` | `string` | no | `"descriptor"` for fluent descriptor chains, or `"object_initializer"` for object initializers. The default is `"descriptor"`. |
-| `use_strongly_typed_document` | `boolean` | no | If `true`, field accessors use lambdas on an illustrative document type. The default is `true`. |
-| `document_type_name` | `string` | no | The document type name used in generated code. The default is `"MyDocument"`. |
-| `type_name_style` | `string` | no | `"Simplified"`, `"Fqn"`, or `"GlobalFqn"` type-name rendering. The default is `"Simplified"`. |
 | `client_call_format` | `string` | no | `"none"`, `"statement"`, or `"inline"`: whether and how the client invocation that executes the request is emitted. The default is `"none"`. |
 | `client_call_style` | `string` | no | `"async"` or `"sync"` invocation flavor when `client_call_format` is not `"none"`. The default is `"async"`. |
 | `debug` | `boolean` | no | If `true`, append converter diagnostics to error messages. The default is `false`. |
+| `document_type_name` | `string` | no | The document type name used in generated code. The default is `"MyDocument"`. |
+| `syntax_mode` | `string` | no | `"descriptor"` for fluent descriptor chains, or `"object_initializer"` for object initializers. The default is `"descriptor"`. |
+| `type_name_style` | `string` | no | `"Simplified"`, `"Fqn"`, or `"GlobalFqn"` type-name rendering. The default is `"Simplified"`. |
+| `use_strongly_typed_document` | `boolean` | no | If `true`, field accessors use lambdas on an illustrative document type. The default is `true`. |
 
 ## Command-Line Interface
 

--- a/tests/convert.test.ts
+++ b/tests/convert.test.ts
@@ -759,6 +759,28 @@ response1 = client.search(
       expect(code).toContain('"syntax_mode":"object_initializer"');
     });
 
+    it("passes the client call options through", async () => {
+      const { CSharpExporter } = await import("../src/exporters/csharp");
+      const code = await convertRequests(
+        "GET /my-index/_search\n{}",
+        new CSharpExporter(fixture),
+        { client_call_format: "inline", client_call_style: "sync" },
+      );
+      expect(code).toContain('"client_call_format":"inline"');
+      expect(code).toContain('"client_call_style":"sync"');
+    });
+
+    it("sends no client call options by default", async () => {
+      const { CSharpExporter } = await import("../src/exporters/csharp");
+      const code = await convertRequests(
+        "GET /my-index/_search\n{}",
+        new CSharpExporter(fixture),
+        {},
+      );
+      expect(code).not.toContain("client_call_format");
+      expect(code).not.toContain("client_call_style");
+    });
+
     it("is listed as a format", () => {
       expect(listFormats()).toContain("C#");
     });


### PR DESCRIPTION
## Summary

Documents the C# exporter's upcoming `client_call_format` and `client_call_style` options and pins their
pass-through with tests against the options-echoing mock bundle. No TypeScript source changes: exporter-specific
options ride the `ConvertOptions` index signature and serialize verbatim to the bundle, like the existing C#
options.

## Intention

The next `@elastic/request-converter-dotnet` release can append the client invocation that executes a converted
request (`var response = await client.SearchAsync<MyDocument>(s => s.Query(...));`). The host already forwards
arbitrary options; these tests pin that contract so the new options keep flowing, and the README documents them.

## Changes

- README: two new rows in the C# options table (sorted alphabetically).
- CHANGES: unreleased entry.
- Tests: options are forwarded when given and absent by default.

## Related

Companion .NET PRs: https://github.com/elastic/elasticsearch-net/pull/8951 and
https://github.com/elastic/elastic-client-generator-net/pull/200

## Notes

Inert until a bundle containing client-call support is published.