### PR TITLE
Document and test the C# emit_usings option pass-through

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Document and test pass-through of the C# exporter's `client_call_format` and `client_call_style` options
+* Document and test pass-through of the C# exporter's `emit_usings` option
 
 ## 9.2.1 (2025-11-12)
 * Write correctly formatted ndjson bodies in the curl exporter ([#99](https://github.com/elastic/request-converter/pull/99))

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Supported options (snake_case, matching the .NET bundle's wire contract):
 | `client_call_style` | `string` | no | `"async"` or `"sync"` invocation flavor when `client_call_format` is not `"none"`. The default is `"async"`. |
 | `debug` | `boolean` | no | If `true`, append converter diagnostics to error messages. The default is `false`. |
 | `document_type_name` | `string` | no | The document type name used in generated code. The default is `"MyDocument"`. |
+| `emit_usings` | `boolean` | no | If `false`, the generated code omits the `using` directives for the referenced namespaces. The default is `true`. |
 | `syntax_mode` | `string` | no | `"descriptor"` for fluent descriptor chains, or `"object_initializer"` for object initializers. The default is `"descriptor"`. |
 | `type_name_style` | `string` | no | `"Simplified"`, `"Fqn"`, or `"GlobalFqn"` type-name rendering. The default is `"Simplified"`. |
 | `use_strongly_typed_document` | `boolean` | no | If `true`, field accessors use lambdas on an illustrative document type. The default is `true`. |

--- a/tests/convert.test.ts
+++ b/tests/convert.test.ts
@@ -781,6 +781,26 @@ response1 = client.search(
       expect(code).not.toContain("client_call_style");
     });
 
+    it("passes the emit usings option through", async () => {
+      const { CSharpExporter } = await import("../src/exporters/csharp");
+      const code = await convertRequests(
+        "GET /my-index/_search\n{}",
+        new CSharpExporter(fixture),
+        { emit_usings: false },
+      );
+      expect(code).toContain('"emit_usings":false');
+    });
+
+    it("sends no emit usings option by default", async () => {
+      const { CSharpExporter } = await import("../src/exporters/csharp");
+      const code = await convertRequests(
+        "GET /my-index/_search\n{}",
+        new CSharpExporter(fixture),
+        {},
+      );
+      expect(code).not.toContain("emit_usings");
+    });
+
     it("is listed as a format", () => {
       expect(listFormats()).toContain("C#");
     });


### PR DESCRIPTION
## Summary

Documents the C# exporter's upcoming `emit_usings` option (README table row, changelog) and pins its pass-through
with fixture tests. No TypeScript source changes: like the other C# options, it rides the `ConvertOptions` index
signature and serializes verbatim to the bundle.

## Related

Stacked on #126. Companion .NET change: https://github.com/elastic/elasticsearch-net/pull/8953

## Notes

Inert until a bundle containing the option is published.